### PR TITLE
Revert "Fix https issue: Use wp_upload_dir path plus filename, rather th...

### DIFF
--- a/lib/ManualImageCrop.php
+++ b/lib/ManualImageCrop.php
@@ -153,17 +153,14 @@ setInterval(function() {
 			exit;
 		}
 
-                // User uploadsDir path to avoid http vs. https conflicts in URL matching.
-                // This assumes the wp_upload_dir() path is correct, which seems reasonable
-                $src_file = trailingslashit($uploadsDir['path']) . basename($src_file_url[0]);
+		$src_file = str_replace($uploadsDir['baseurl'], $uploadsDir['basedir'], $src_file_url[0]);
 
-                $dst_file_url = wp_get_attachment_image_src($_POST['attachmentId'], $_POST['editedSize']);
-                if (!$dst_file_url) {
-                        echo json_encode (array('status' => 'error', 'message' => 'wrong size' ) );
-                        exit;
-                }
-
-                $dst_file = trailingslashit($uploadsDir['path']) . basename($dst_file_url[0]);
+		$dst_file_url = wp_get_attachment_image_src($_POST['attachmentId'], $_POST['editedSize']);
+		if (!$dst_file_url) {
+			echo json_encode (array('status' => 'error', 'message' => 'wrong size' ) );
+			exit;
+		}
+		$dst_file = str_replace($uploadsDir['baseurl'], $uploadsDir['basedir'], $dst_file_url[0]);
 
 		//checks if the destination image file is present (if it's not, we want to create a new file, as the WordPress returns the original image instead of specific one)
 		if ($dst_file == $src_file) {


### PR DESCRIPTION
...an relying on string matching."

This reverts commit 78acfb5784abe2dc936b654ab2c3827653ab9ffe.

My fix breaks when the year/month of the image being cropped is different from the current year/month. The upstream method is more reliable, grungy though it is.
