### PR TITLE
Addresses Undefined index warning for ['mic_quality']

### DIFF
--- a/lib/ManualImageCrop.php
+++ b/lib/ManualImageCrop.php
@@ -217,7 +217,7 @@ setInterval(function() {
 																);
 		wp_update_attachment_metadata($_POST['attachmentId'], $imageMetadata);
 		
-		$quality = intval($_POST['mic_quality']);
+		$quality = isset($_POST['mic_quality']) ? intval($_POST['mic_quality']) : 60;
 
         if ( function_exists('wp_get_image_editor') ) {
             $img = wp_get_image_editor( $src_file );


### PR DESCRIPTION
Tom - you may have a different default (aside from 60 - maybe 0?) to use for this.  This addresses an issue where the Ajax request returns PHP notices when `WP_DEBUG` is `true` and `mic_quality` was not set in the `$_POST` global. 