### PR TITLE
Fix MIC Custom Settings Not Saving bug

### DIFF
--- a/lib/ManualImageCropSettingsPage.php
+++ b/lib/ManualImageCropSettingsPage.php
@@ -148,7 +148,7 @@ class MicSettingsPage
 			 </thead>
              <tbody>';
 		
-		$sizesSettings = self::getSettings() || array();
+		$sizesSettings = self::getSettings();
 		
 		foreach ($imageSizes as $s) {
 			$label = isset($sizeLabels[$s]) ? $sizeLabels[$s] : ucfirst( str_replace( '-', ' ', $s ) );


### PR DESCRIPTION
Fix MIC Custom Settings not saving bug, that is described here: https://wordpress.org/support/topic/mic-custom-settings-not-saving