### PR TITLE
Fix 2x image generation

### DIFF
--- a/lib/ManualImageCrop.php
+++ b/lib/ManualImageCrop.php
@@ -336,7 +336,7 @@ class ManualImageCrop {
 		}
 
 		// Generate Retina Image
-		if( isset( $data['make2x'] ) && $data['make2x'] === 'true' ) {
+		if( isset( $data['make2x'] ) && $data['make2x'] === true ) {
 			$dst_w2x = $dst_w * 2;
 			$dst_h2x = $dst_h * 2;
 

--- a/lib/ManualImageCropEditorWindow.php
+++ b/lib/ManualImageCropEditorWindow.php
@@ -219,7 +219,7 @@ class ManualImageCropEditorWindow {
                 if ( is_plugin_active('wp-retina-2x/wp-retina-2x.php') ) { ?>
 		<div class="mic-option">
 			<input type="checkbox" id="mic-make-2x"
-			<?php if(get_option('mic_make2x') === 'true' ) echo 'checked="checked"' ?> />
+			<?php if(get_option('mic_make2x')) echo 'checked="checked"' ?> />
 			<label for="mic-make-2x"><?php _e('Generate Retina/HiDPI (@2x):', 'microp') ?>
 				<span id="mic-2x-status"></span> </label>
 		</div>


### PR DESCRIPTION
2x images weren't being generated because with the input data being sanitized, the `make2x` checkbox value evaluates to boolean `true`, not string 'true'.
