### PR TITLE
Add filters and actions

### DIFF
--- a/lib/ManualImageCrop.php
+++ b/lib/ManualImageCrop.php
@@ -385,6 +385,10 @@ class ManualImageCrop {
 			update_option('mic_make2x', $data['make2x']);
 		}
 
+		// run an action that other scripts can hook into, letting them
+		// know that the cropping is done for the given image
+		do_action('mic_crop_done', $data, $imageMetadata);
+
 		//returns the url to the generated image (to allow refreshing the preview)
 		echo json_encode (array('status' => 'ok', 'file' => $dst_file_url[0] ) );
 		exit;

--- a/lib/ManualImageCrop.php
+++ b/lib/ManualImageCrop.php
@@ -293,9 +293,10 @@ class ManualImageCrop {
 		);
 		wp_update_attachment_metadata($data['attachmentId'], $imageMetadata);
 
-		$do_crop = apply_filters( 'mic_do_crop', true, $imageMetadata );
+		$dims = array( $dst_x, $dst_y, $src_x, $src_y, $dst_w, $dst_h, $src_w, $src_h );
+		$do_crop = apply_filters( 'mic_do_crop', true, $imageMetadata, $dims );
 		if ( !$do_crop ) {
-			// Another plugin has already taken care of the croppng.
+			// Another plugin has already taken care of the cropping.
 			$this->cropSuccess( $data, $dst_file_url );
 		}
 

--- a/lib/ManualImageCrop.php
+++ b/lib/ManualImageCrop.php
@@ -84,11 +84,11 @@ class ManualImageCrop {
 <script>
 		var micEditAttachemtnLinkAdded = false;
 		var micEditAttachemtnLinkAddedInterval = 0;
-		jQuery(document).ready(function() {			
+		jQuery(document).ready(function() {
 			micEditAttachemtnLinkAddedInterval = setInterval(function() {
 				if (jQuery('.details .edit-attachment').length) {
 					try {
-						var mRegexp = /\?post=([0-9]+)/; 
+						var mRegexp = /\?post=([0-9]+)/;
 						var match = mRegexp.exec(jQuery('.details .edit-attachment').attr('href'));
 						jQuery('.crop-image-ml.crop-image').remove();
 						jQuery('.details .edit-attachment').after( '<a class="thickbox mic-link crop-image-ml crop-image" rel="crop" title="<?php _e("Manual Image Crop","microp"); ?>" href="' + ajaxurl + '?action=mic_editor_window&postId=' + match[1] + '"><?php _e('Crop Image','microp') ?></a>' );
@@ -125,7 +125,7 @@ class ManualImageCrop {
 				if (jQuery('#media-items .edit-attachment').length) {
 					jQuery('#media-items .edit-attachment').each(function(i, k) {
 						try {
-							var mRegexp = /\?post=([0-9]+)/; 
+							var mRegexp = /\?post=([0-9]+)/;
 							var match = mRegexp.exec(jQuery(this).attr('href'));
 							if (!jQuery(this).parent().find('.edit-attachment.crop-image').length && jQuery(this).parent().find('.pinkynail').attr('src').match(/upload/g)) {
 								jQuery(this).after( '<a class="thickbox mic-link edit-attachment crop-image" rel="crop" title="<?php _e("Manual Image Crop","microp"); ?>" href="' + ajaxurl + '?action=mic_editor_window&postId=' + match[1] + '"><?php _e('Crop Image','microp') ?></a>' );
@@ -140,12 +140,12 @@ class ManualImageCrop {
 	</script>
 <?php
 	}
-	
+
 	private function filterPostData() {
 		$imageSizes = get_intermediate_image_sizes();
-	
+
 		$data = array(
-				'attachmentId' => filter_var($_POST['attachmentId'], FILTER_SANITIZE_NUMBER_INT),			
+				'attachmentId' => filter_var($_POST['attachmentId'], FILTER_SANITIZE_NUMBER_INT),
 				'editedSize' => in_array($_POST['editedSize'], $imageSizes) ? $_POST['editedSize'] : null,
 				'select' => array(
 							'x' => filter_var($_POST['select']['x'], FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION),
@@ -154,7 +154,7 @@ class ManualImageCrop {
 							'h' => filter_var($_POST['select']['h'], FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION),
 						),
 				'previewScale' => filter_var($_POST['previewScale'], FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION)
-				
+
 		);
 
 		if (isset($_POST['mic_quality'])) {
@@ -170,12 +170,23 @@ class ManualImageCrop {
 		return $data;
 	}
 
+	public function cropSuccess( $data, $dst_file_url ) {
+		// update 'mic_make2x' option status to persist choice
+		if( isset( $data['make2x'] ) && $data['make2x'] !== get_option('mic_make2x') ) {
+			update_option('mic_make2x', $data['make2x']);
+		}
+
+		//returns the url to the generated image (to allow refreshing the preview)
+		echo json_encode (array('status' => 'ok', 'file' => $dst_file_url[0] ) );
+		exit;
+	}
+
 	/**
 	 * Crops the image based on params passed in $_POST array
 	 */
 	public function cropImage() {
 		global $_wp_additional_image_sizes;
-		
+
 		$data = $this->filterPostData();
 
 		$dst_file_url = wp_get_attachment_image_src($data['attachmentId'], $data['editedSize']);
@@ -208,19 +219,22 @@ class ManualImageCrop {
 			$dst_file = str_replace( $uploadsDir['baseurl'], $uploadsDir['basedir'], $dst_file_url[0] );
 		}
 
+		$dst_file = apply_filters( 'mic_dst_file_path', $dst_file, $data );
+		$dst_file_url[0] = apply_filters( 'mic_dst_file_url', $dst_file_url[0], $data );
+
 		//checks if the destination image file is present (if it's not, we want to create a new file, as the WordPress returns the original image instead of specific one)
 		if ($dst_file == $src_file) {
 			$attachmentData = wp_generate_attachment_metadata( $data['attachmentId'], $dst_file );
-				
+
 			//overwrite with previous values
 			$prevAttachmentData = wp_get_attachment_metadata($data['attachmentId']);
 			if (isset($prevAttachmentData['micSelectedArea'])) {
 				$attachmentData['micSelectedArea'] = $prevAttachmentData['micSelectedArea'];
 			}
-				
+
 			//saves new path to the image size in the database
 			wp_update_attachment_metadata( $data['attachmentId'],  $attachmentData );
-				
+
 			//new destination file path - replaces original file name with the correct one
 			$dst_file = str_replace( basename($attachmentData['file']), $attachmentData['sizes'][ $data['editedSize'] ]['file'], $dst_file);
 
@@ -278,6 +292,12 @@ class ManualImageCrop {
 				'scale' => $data['previewScale'],
 		);
 		wp_update_attachment_metadata($data['attachmentId'], $imageMetadata);
+
+		$do_crop = apply_filters( 'mic_do_crop', true, $imageMetadata );
+		if ( !$do_crop ) {
+			// Another plugin has already taken care of the croppng.
+			$this->cropSuccess( $data, $dst_file_url );
+		}
 
 		if ( function_exists('wp_get_image_editor') ) {
 			$img = wp_get_image_editor( $src_file );
@@ -372,7 +392,7 @@ class ManualImageCrop {
 					} else {
 						$imageSaveReturn = imagejpeg($dst_img2x, $dst_file2x, $quality);
 					}
-						
+
 					if ($imageSaveReturn === false ) {
 						echo json_encode (array('status' => 'error', 'message' => 'PHP ERROR: imagejpeg/imagegif/imagepng' ) );
 						exit;
@@ -380,13 +400,6 @@ class ManualImageCrop {
 				}
 			}
 		}
-		// update 'mic_make2x' option status to persist choice
-		if( isset( $data['make2x'] ) && $data['make2x'] !== get_option('mic_make2x') ) {
-			update_option('mic_make2x', $data['make2x']);
-		}
-
-		//returns the url to the generated image (to allow refreshing the preview)
-		echo json_encode (array('status' => 'ok', 'file' => $dst_file_url[0] ) );
-		exit;
+		$this->cropSuccess( $data, $dst_file_url );
 	}
 }

--- a/manual-image-crop.php
+++ b/manual-image-crop.php
@@ -3,7 +3,7 @@
 Plugin Name: Manual Image Crop
 Plugin URI: https://github.com/tomaszsita/wp-manual-image-crop
 Description: Plugin allows you to manually crop all the image sizes registered in your WordPress theme (in particular featured image). Simply click on the "Crop" link next to any image in your media library and select the area of the image you want to crop.
-Version: 1.13-bgmp
+Version: 1.12
 Author: Tomasz Sita
 Author URI: https://github.com/tomaszsita
 License: GPL2

--- a/manual-image-crop.php
+++ b/manual-image-crop.php
@@ -3,7 +3,7 @@
 Plugin Name: Manual Image Crop
 Plugin URI: https://github.com/tomaszsita/wp-manual-image-crop
 Description: Plugin allows you to manually crop all the image sizes registered in your WordPress theme (in particular featured image). Simply click on the "Crop" link next to any image in your media library and select the area of the image you want to crop.
-Version: 1.12
+Version: 1.13-bgmp
 Author: Tomasz Sita
 Author URI: https://github.com/tomaszsita
 License: GPL2

--- a/readme.txt
+++ b/readme.txt
@@ -55,7 +55,7 @@ Please contact me if you want to add a translation (or submit a pull request on 
 The plugin includes filters that can be used by other plugins:
 
 =mic_do_crop=
-Provides $do_crop (bool) and $metadata (array). Returning false for $do_crop will prevent Manual Image Crop from cropping the image. $metadata contains the crop parameters, so another plugin can take over the actual cropping.
+Provides $do_crop (bool), $metadata (array), and $dims (array). Returning false for $do_crop will prevent Manual Image Crop from cropping the image. $metadata contains the crop parameters, so another plugin can take over the actual cropping.
 
 =mic_dst_file_path=
 Provides $path (string) and $data (array). Manual Image Crop will write the new image to $path and save that path to the image metadata. $data contains the crop parameters that the user chose in WordPress admin.

--- a/readme.txt
+++ b/readme.txt
@@ -10,6 +10,14 @@ Stable tag: 1.12
 
 Plugin allows you to manually crop all the image sizes registered in your WordPress theme (in particular featured image).
 
+=== About This Branch ===
+
+The "v1.13-bgmp" branch of the plugin includes some pull requests that haven't been merged back to the main repository yet. Once the pull requests are merged back, this branch will be deprecated in favor of the mainline version of the plugin.
+
+Included pull requests:
+- https://github.com/tomaszsita/wp-manual-image-crop/pull/46
+- https://github.com/tomaszsita/wp-manual-image-crop/pull/47
+
 == Description ==
 Plugin allows you to manually crop all the image sizes registered in your WordPress theme (in particular featured image).
 Simply click on the "Crop" link next to any image in your media library.

--- a/readme.txt
+++ b/readme.txt
@@ -12,7 +12,7 @@ Plugin allows you to manually crop all the image sizes registered in your WordPr
 
 == Description ==
 Plugin allows you to manually crop all the image sizes registered in your WordPress theme (in particular featured image).
-Simply click on the "Crop" link next to any image in your media library. 
+Simply click on the "Crop" link next to any image in your media library.
 The "lightbox" style interface will be brought up and you are ready to go.
 Whole cropping process is really intuitive and simple.
 
@@ -47,9 +47,21 @@ Please contact me if you want to add a translation (or submit a pull request on 
 *   Activate the plugin through the 'Plugins' menu in WordPress
 
 = Automatically: =
-*   Navigate to the 'Plugins' menu inside of the wordpress wp-admin dashboard, and select AD NEW 
-*   Search for 'Manual Imag Crop', and click install 
-*   When the plugin has been installed, Click 'Activate' 
+*   Navigate to the 'Plugins' menu inside of the wordpress wp-admin dashboard, and select AD NEW
+*   Search for 'Manual Imag Crop', and click install
+*   When the plugin has been installed, Click 'Activate'
+
+== Filters ==
+The plugin includes filters that can be used by other plugins:
+
+=mic_do_crop=
+Provides $do_crop (bool) and $metadata (array). Returning false for $do_crop will prevent Manual Image Crop from cropping the image. $metadata contains the crop parameters, so another plugin can take over the actual cropping.
+
+=mic_dst_file_path=
+Provides $path (string) and $data (array). Manual Image Crop will write the new image to $path and save that path to the image metadata.
+
+=mic_dst_file_url=
+Provides $url (string) and $data (array). Manual Image Crop will return $url in an AJAX response if the image crop is successful. The admin screen uses this URL to display the updated image. This URL is not stored with the image or used elsewhere in WordPress. wp_get_attachment_image_src is used instead to generate the image URL.
 
 == Changelog ==
 = 1.12 =
@@ -65,7 +77,7 @@ Please contact me if you want to add a translation (or submit a pull request on 
 
 = 1.09 =
 * Dutch translation added
-* Better error handling 
+* Better error handling
 * Fixed overwriting of previously saved crops
 * Minor tweaks all around
 

--- a/readme.txt
+++ b/readme.txt
@@ -69,7 +69,7 @@ The admin screen uses this URL to display the updated image. This URL is not sto
 The plugin includes actions that can be used by other plugins:
 
 = mic_crop_done =
-Triggered after a crop has been successfully completed, immediately before the JSON response is sent to the browser.
+Triggered after a crop has been successfully completed, immediately before the JSON response is sent to the browser. Provides $data (array) and $imageMetadata (array).
 
 == Changelog ==
 = 1.12 =

--- a/readme.txt
+++ b/readme.txt
@@ -12,7 +12,7 @@ Plugin allows you to manually crop all the image sizes registered in your WordPr
 
 == Description ==
 Plugin allows you to manually crop all the image sizes registered in your WordPress theme (in particular featured image).
-Simply click on the "Crop" link next to any image in your media library. 
+Simply click on the "Crop" link next to any image in your media library.
 The "lightbox" style interface will be brought up and you are ready to go.
 Whole cropping process is really intuitive and simple.
 
@@ -47,9 +47,21 @@ Please contact me if you want to add a translation (or submit a pull request on 
 *   Activate the plugin through the 'Plugins' menu in WordPress
 
 = Automatically: =
-*   Navigate to the 'Plugins' menu inside of the wordpress wp-admin dashboard, and select AD NEW 
-*   Search for 'Manual Imag Crop', and click install 
-*   When the plugin has been installed, Click 'Activate' 
+*   Navigate to the 'Plugins' menu inside of the wordpress wp-admin dashboard, and select AD NEW
+*   Search for 'Manual Imag Crop', and click install
+*   When the plugin has been installed, Click 'Activate'
+
+== Filters ==
+The plugin includes filters that can be used by other plugins:
+
+=mic_do_crop=
+Provides $do_crop (bool) and $metadata (array). Returning false for $do_crop will prevent Manual Image Crop from cropping the image. $metadata contains the crop parameters, so another plugin can take over the actual cropping.
+
+=mic_dst_file_path=
+Provides $path (string) and $data (array). Manual Image Crop will write the new image to $path and save that path to the image metadata. $data contains the crop parameters that the user chose in WordPress admin.
+
+=mic_dst_file_url=
+Provides $url (string) and $data (array). Manual Image Crop will return $url in an AJAX response if the image crop is successful. The admin screen uses this URL to display the updated image. This URL is not stored with the image or used elsewhere in WordPress. wp_get_attachment_image_src is used instead to generate the image URL. $data contains the crop parameters that the user chose in WordPress admin.
 
 == Changelog ==
 = 1.12 =
@@ -65,7 +77,7 @@ Please contact me if you want to add a translation (or submit a pull request on 
 
 = 1.09 =
 * Dutch translation added
-* Better error handling 
+* Better error handling
 * Fixed overwriting of previously saved crops
 * Minor tweaks all around
 

--- a/readme.txt
+++ b/readme.txt
@@ -10,14 +10,6 @@ Stable tag: 1.12
 
 Plugin allows you to manually crop all the image sizes registered in your WordPress theme (in particular featured image).
 
-=== About This Branch ===
-
-The "v1.13-bgmp" branch of the plugin includes some pull requests that haven't been merged back to the main repository yet. Once the pull requests are merged back, this branch will be deprecated in favor of the mainline version of the plugin.
-
-Included pull requests:
-- https://github.com/tomaszsita/wp-manual-image-crop/pull/46
-- https://github.com/tomaszsita/wp-manual-image-crop/pull/47
-
 == Description ==
 Plugin allows you to manually crop all the image sizes registered in your WordPress theme (in particular featured image).
 Simply click on the "Crop" link next to any image in your media library.

--- a/readme.txt
+++ b/readme.txt
@@ -51,6 +51,12 @@ Please contact me if you want to add a translation (or submit a pull request on 
 *   Search for 'Manual Imag Crop', and click install 
 *   When the plugin has been installed, Click 'Activate' 
 
+== Actions ==
+The plugin includes actions that can be used by other plugins:
+
+= mic_crop_done =
+Triggered after a crop has been successfully completed, immediately before the JSON response is sent to the browser.
+
 == Changelog ==
 = 1.12 =
 * Fixed 'streched images' issue


### PR DESCRIPTION
I've added a few filters to the plugin so that other plugins can interact with it. I think this should address the request in #37. @firejdl has added an action that runs when the crop is done. This change solves issue #25.

My text editor also removed some space at the ends of lines, for some reason.

Anyway, I'd love to hear your thoughts! Feel free to let me know if you'd like to see any changes or if this can be merged as-is. Manual Image Crop rocks - thanks so much for developing it!
## filters
### mic_do_crop

Provides `$do_crop` (bool), `$metadata` (array), and `$dims` (array). Returning false for `$do_crop` will prevent Manual Image Crop from cropping the image. `$metadata` contains the crop parameters, so another plugin can take over the actual cropping.
### mic_dst_file_path

Provides `$path` (string) and `$data` (array). Manual Image Crop will write the new image to `$path` and save that path to the image metadata. `$data` contains the crop parameters that the user chose in WordPress admin.
### mic_dst_file_url

Provides `$url` (string) and `$data` (array). Manual Image Crop will return `$url` in an AJAX response if the image crop is successful. `$data` contains the crop parameters that the user chose in WordPress admin.
## actions
### mic_crop_done

Triggered after a crop has been successfully completed, immediately before the JSON response is sent to the browser. Provides `$data` (array) and `$imageMetadata` (array).
