### PR TITLE
Updated backend UI. Added new option to show cropping popup on new uploads.

### DIFF
--- a/assets/css/mic-admin.css
+++ b/assets/css/mic-admin.css
@@ -158,3 +158,7 @@ th.mic-quality {
 th.mic-label {
 	width: 240px;
 }
+
+td.mic-size {
+	font-weight: 700;
+}

--- a/assets/css/mic-admin.css
+++ b/assets/css/mic-admin.css
@@ -141,3 +141,20 @@
 	padding: 8px 10px;
 	font-weight: 400;
 }
+
+.mic-table {
+	max-width: 1000px;
+}
+
+th.mic-size {
+	width: auto;
+}
+th.mic-visible {
+	width: 120px;
+}
+th.mic-quality {
+	width: 300px;
+}
+th.mic-label {
+	width: 240px;
+}

--- a/assets/css/mic-admin.css
+++ b/assets/css/mic-admin.css
@@ -99,3 +99,9 @@
 .mic-option {
 	margin-top: 10px;
 }
+
+.attachment-info .mic-link.crop-image {
+	display: block;
+	text-decoration: none;
+	white-space: nowrap;
+}

--- a/assets/css/mic-admin.css
+++ b/assets/css/mic-admin.css
@@ -105,3 +105,34 @@
 	text-decoration: none;
 	white-space: nowrap;
 }
+
+.attachment-info .mic-link.crop-image {
+	display: block;
+	text-decoration: none;
+	white-space: nowrap;
+}
+
+.mic-editor-wrapper h2 .nav-tab {
+	font-weight: 400;
+	font-size: 14px;
+	padding: 6px 12px;
+
+	color: #21759b;
+	background: none;
+	border: none;
+}
+
+.mic-editor-wrapper h2 .nav-tab:hover {
+	color: #d54e21;
+}
+
+.mic-editor-wrapper h2 .nav-tab-active {
+	color: #32373c;
+	background: #fff;
+	border: 1px solid #ddd;
+	border-bottom: none;
+}
+
+.mic-editor-wrapper h2 .nav-tab-active:hover {
+	color: #32373c;
+}

--- a/assets/css/mic-admin.css
+++ b/assets/css/mic-admin.css
@@ -136,3 +136,8 @@
 .mic-editor-wrapper h2 .nav-tab-active:hover {
 	color: #32373c;
 }
+
+.widefat.mic-table th {
+	padding: 8px 10px;
+	font-weight: 400;
+}

--- a/assets/js/microp.js
+++ b/assets/js/microp.js
@@ -66,4 +66,17 @@ jQuery(document).ready(function($) {
 	 
 	 setInterval(adjustMicWindowSize, 200);
 
+	// Prompt to crop featured images automatically, if set in settings page
+	if ( typeof mic_autocrop_uploads != 'undefined' && typeof wp.Uploader != 'undefined' ) {
+		// When the uploader receives a new image, invoke the crop feature.
+		$.extend( wp.Uploader.prototype, {
+			success : function( file_attachment ){
+				if ( file_attachment.id ) {
+					var crop_url = '/wp-admin/admin-ajax.php?action=mic_editor_window&postId=' + file_attachment.id;
+					tb_show( mic_autocrop_uploads, crop_url );
+				}
+			}
+		});
+	}
+
 });

--- a/lib/ManualImageCrop.php
+++ b/lib/ManualImageCrop.php
@@ -85,9 +85,6 @@ class ManualImageCrop {
 		var micEditAttachemtnLinkAdded = false;
 		var micEditAttachemtnLinkAddedInterval = 0;
 
-		var micInsertAttachmentLinkElement = function() {
-		};
-
 		jQuery(document).ready(function() {
 			micEditAttachemtnLinkAddedInterval = setInterval(function() {
 				var $mediaEditLink = jQuery('.details .edit-attachment');

--- a/lib/ManualImageCrop.php
+++ b/lib/ManualImageCrop.php
@@ -84,16 +84,25 @@ class ManualImageCrop {
 <script>
 		var micEditAttachemtnLinkAdded = false;
 		var micEditAttachemtnLinkAddedInterval = 0;
-		jQuery(document).ready(function() {			
+
+		var micInsertAttachmentLinkElement = function() {
+		};
+
+		jQuery(document).ready(function() {
 			micEditAttachemtnLinkAddedInterval = setInterval(function() {
-				if (jQuery('.details .edit-attachment').length) {
-					try {
-						var mRegexp = /\?post=([0-9]+)/; 
-						var match = mRegexp.exec(jQuery('.details .edit-attachment').attr('href'));
-						jQuery('.crop-image-ml.crop-image').remove();
-						jQuery('.details .edit-attachment').after( '<a class="thickbox mic-link crop-image-ml crop-image" rel="crop" title="<?php _e("Manual Image Crop","microp"); ?>" href="' + ajaxurl + '?action=mic_editor_window&postId=' + match[1] + '"><?php _e('Crop Image','microp') ?></a>' );
-					} catch (e) {
-						console.log(e);
+				var $mediaEditLink = jQuery('.details .edit-attachment');
+
+				if ($mediaEditLink.length) {
+					// Check if we already have the "Crop Image" link before adding a new one
+					if ( $mediaEditLink.siblings('.crop-image-ml.crop-image').length == 0 ) {
+						try {
+							var mRegexp = /\?post=([0-9]+)/;
+							var match = mRegexp.exec($mediaEditLink.attr('href'));
+							jQuery('.crop-image-ml.crop-image').remove();
+							$mediaEditLink.after( '<a class="thickbox mic-link crop-image-ml crop-image" rel="crop" title="<?php _e("Manual Image Crop","microp"); ?>" href="' + ajaxurl + '?action=mic_editor_window&postId=' + match[1] + '"><?php _e('Crop Image','microp') ?></a>' );
+						} catch (e) {
+							console.log(e);
+						}
 					}
 				}
 

--- a/lib/ManualImageCrop.php
+++ b/lib/ManualImageCrop.php
@@ -29,7 +29,7 @@ class ManualImageCrop {
 	public function enqueueAssets() {
 		add_thickbox();
 
-		wp_register_style( 'rct-admin', plugins_url('assets/css/mic-admin.css', dirname( __FILE__ ) ) );
+		wp_register_style( 'rct-admin', plugins_url('assets/css/mic-admin.css', dirname( __FILE__ ) ), array(), mic_VERSION );
 		wp_enqueue_style( 'rct-admin' );
 
 		wp_register_style( 'jquery-jcrop', plugins_url('assets/css/jquery.Jcrop.min.css', dirname( __FILE__ ) ) );
@@ -37,7 +37,7 @@ class ManualImageCrop {
 
 		wp_enqueue_script( 'jquery-color', plugins_url('assets/js/jquery.color.js', dirname( __FILE__ )), array( 'jquery') );
 		wp_enqueue_script( 'jquery-jcrop', plugins_url('assets/js/jquery.Jcrop.min.js', dirname( __FILE__ )), array( 'jquery') );
-		wp_enqueue_script( 'miccrop', plugins_url('assets/js/microp.js', dirname( __FILE__ )), array( 'jquery') );
+		wp_enqueue_script( 'miccrop', plugins_url('assets/js/microp.js', dirname( __FILE__ )), array( 'jquery'), mic_VERSION );
 	}
 
 	/**

--- a/lib/ManualImageCropSettingsPage.php
+++ b/lib/ManualImageCropSettingsPage.php
@@ -140,10 +140,10 @@ class MicSettingsPage
 		echo '<table class="widefat fixed mic-table" cellspacing="0">';
 		echo '<thead>
 			  <tr>
-			     <th>' . __('Size', 'microp') . '</th>
-			     <th>' . __('Visible', 'microp') . '</th>
-			     <th>' . __('Default JPEG Quality', 'microp') . '</th>
-			     <th>' . __('Custom Label', 'microp') . '</th>
+			     <th class="mic-size">' . __('Size', 'microp') . '</th>
+			     <th class="mic-visible">' . __('Visible', 'microp') . '</th>
+			     <th class="mic-quality">' . __('Default JPEG Quality', 'microp') . '</th>
+			     <th class="mic-label">' . __('Custom Label', 'microp') . '</th>
 			  </tr>
 			 </thead>
              <tbody>';

--- a/lib/ManualImageCropSettingsPage.php
+++ b/lib/ManualImageCropSettingsPage.php
@@ -137,7 +137,7 @@ class MicSettingsPage
         ) );
         $sizeLabels = apply_filters( 'image_size_names_choose', array() );
 		
-		echo '<table class="widefat fixed mic-table" cellspacing="0">';
+		echo '<table class="widefat fixed mic-table striped" cellspacing="0">';
 		echo '<thead>
 			  <tr>
 			     <th class="mic-size">' . __('Size', 'microp') . '</th>
@@ -166,12 +166,12 @@ class MicSettingsPage
 			}
 			
 			echo '<tr>
-			     <td>' . $label. '</td>
-			     <td><select name="mic_options[sizes_settings][' . $s . '][visibility]">
+			     <td class="mic-size">' . $label. '</td>
+			     <td class="mic-visible"><select name="mic_options[sizes_settings][' . $s . '][visibility]">
      					<option value="visible">' . __('Yes', 'microp') . '</option>
      					<option value="hidden" ' . ( $sizesSettings[$s]['visibility'] == 'hidden' ? 'selected' : '' ) . '>' . __('No', 'microp') . '</option>
     				</select></td>
-			     <td><select name="mic_options[sizes_settings][' . $s . '][quality]">
+			     <td class="mic-quality"><select name="mic_options[sizes_settings][' . $s . '][quality]">
      					<option value="100">' . __('100 (best quality, biggest file)', 'microp') . '</option>
      					<option value="80" ' . ( !isset ($sizesSettings[$s]['quality']) || $sizesSettings[$s]['quality'] == '80' ? 'selected' : '' ) . '>' . __('80 (very high quality)', 'microp') . '</option>
      					<option value="70" ' . ( $sizesSettings[$s]['quality'] == '70' ? 'selected' : '' ) . '>' . __('70 (high quality)', 'microp') . '</option>
@@ -180,7 +180,7 @@ class MicSettingsPage
      					<option value="30" ' . ( $sizesSettings[$s]['quality'] == '30' ? 'selected' : '' ) . '>' . __('30 (low)', 'microp') . '</option>
      					<option value="10" ' . ( $sizesSettings[$s]['quality'] == '10' ? 'selected' : '' ) . '>' . __('10 (very low, smallest file)', 'microp') . '</option>
     				</select></td>
-			     <td><input name="mic_options[sizes_settings][' . $s . '][label]" type="text" placeholder="' . $label . '" value="' . str_replace('"', '&quot;', $sizesSettings[$s]['label']) .  '"/></td>
+			     <td class="mic-label"><input name="mic_options[sizes_settings][' . $s . '][label]" type="text" placeholder="' . $label . '" value="' . str_replace('"', '&quot;', $sizesSettings[$s]['label']) .  '"/></td>
 			</tr>';
 		}
 		echo '</tbody></table>';

--- a/lib/ManualImageCropSettingsPage.php
+++ b/lib/ManualImageCropSettingsPage.php
@@ -19,7 +19,7 @@ class MicSettingsPage
      * Fix of settings serialized twice or more
      * @return mixed
      */
-    static function getSettings() {
+    static function getSizesSettings() {
     	$micOptions = get_option( 'mic_options' );
     	if ( ! isset( $micOptions['sizes_settings'] ) ) {
     		return array();
@@ -33,6 +33,15 @@ class MicSettingsPage
     		$settings = unserialize($settings);
     	}
     	return $settings;
+    }
+
+    /**
+     * Return whether or not to automatically open crop page for featured images
+     * @return int
+     */
+    static function getAutocropFeaturedSetting() {
+        $micOptions = get_option( 'mic_options' );
+    	return empty($micOptions['autocrop_featured']) ? 0 : 1;
     }
 
     /**
@@ -84,17 +93,25 @@ class MicSettingsPage
 
         add_settings_section(
             'setting_section_id', // ID
-            __('Mic Custom Settings', 'microp'), // Title
-            array( $this, 'print_section_info' ), // Callback
+            null, // Title
+            null, // Callback
             'Mic-setting-admin' // Page
         );
 
         add_settings_field(
             'sizes_settings', // ID
-            __('Crop sizes settings', 'microp'), // Title 
+            __('Crop sizes settings', 'microp'), // Title
             array( $this, 'sizes_settings_callback' ), // Callback
             'Mic-setting-admin', // Page
-            'setting_section_id' // Section           
+            'setting_section_id' // Section
+        );
+
+        add_settings_field(
+            'autocrop_featured', // ID
+            __('Autocrop featured images setting', 'microp'), // Title
+            array( $this, 'autocrop_featured_callback' ), // Callback
+            'Mic-setting-admin', // Page
+            'setting_section_id' // Section
         );
     }
 
@@ -102,6 +119,8 @@ class MicSettingsPage
      * Sanitize each setting field as needed
      *
      * @param array $input Contains all settings fields as array keys
+     *
+     * @return array
      */
     public function sanitize( $input )
     {
@@ -109,15 +128,12 @@ class MicSettingsPage
         if( isset( $input['sizes_settings'] ) ) {
             $new_input['sizes_settings'] = serialize( $input['sizes_settings'] );
         }
+        if( isset( $input['autocrop_featured'] ) ) {
+            $new_input['autocrop_featured'] = 1;
+        }else{
+            $new_input['autocrop_featured'] = 0;
+        }
         return $new_input;
-    }
-
-    /** 
-     * Print the Section text
-     */
-    public function print_section_info()
-    {
-        print __('Enter your settings below:', 'microp');
     }
 
     /** 
@@ -148,7 +164,7 @@ class MicSettingsPage
 			 </thead>
              <tbody>';
 		
-		$sizesSettings = self::getSettings();
+		$sizesSettings = self::getSizesSettings();
 		if (!is_array($sizesSettings)) {
 			$sizesSettings = array();
 		}
@@ -184,6 +200,24 @@ class MicSettingsPage
 			</tr>';
 		}
 		echo '</tbody></table>';
+		
+    }
+
+    /** 
+     * Display settings for the autocrop option
+     */
+    public function autocrop_featured_callback()
+    {
+        $autocrop = self::getAutocropFeaturedSetting();
+
+        ?>
+        <p>
+            <label>
+                <input type="checkbox" name="mic_options[autocrop_featured]" id="mic-autocrop-featured" <?php checked($autocrop); ?>>
+                <?php _e('Automatically ask to crop featured images on upload', 'microp'); ?>
+            </label>
+        </p>
+        <?php
 		
     }
 }

--- a/lib/ManualImageCropSettingsPage.php
+++ b/lib/ManualImageCropSettingsPage.php
@@ -87,7 +87,7 @@ class MicSettingsPage
             __('Mic Custom Settings', 'microp'), // Title
             array( $this, 'print_section_info' ), // Callback
             'Mic-setting-admin' // Page
-        );  
+        );
 
         add_settings_field(
             'sizes_settings', // ID
@@ -95,7 +95,7 @@ class MicSettingsPage
             array( $this, 'sizes_settings_callback' ), // Callback
             'Mic-setting-admin', // Page
             'setting_section_id' // Section           
-        );          
+        );
     }
 
     /**

--- a/lib/ManualImageCropSettingsPage.php
+++ b/lib/ManualImageCropSettingsPage.php
@@ -137,7 +137,7 @@ class MicSettingsPage
         ) );
         $sizeLabels = apply_filters( 'image_size_names_choose', array() );
 		
-		echo '<table class="widefat fixed" cellspacing="0">';
+		echo '<table class="widefat fixed mic-table" cellspacing="0">';
 		echo '<thead>
 			  <tr>
 			     <th>' . __('Size', 'microp') . '</th>

--- a/lib/plugin-conflicts.php
+++ b/lib/plugin-conflicts.php
@@ -1,0 +1,117 @@
+<?php
+/*
+Displays a message to warn when a conflicting plugin is detected. Provides a link to disable the conflicting plugin, and a short description of the issue.
+
+A user may dismiss the warning which hides it permanently.
+*/
+
+add_action( 'plugins_loaded', 'mic_check_conflicting_plugins', 20 ); // Check for conflicting plugins, display to the admin
+
+/**
+ * Check for plugins known to conflict with MIC
+ */
+function mic_check_conflicting_plugins() {
+	if ( !is_admin() ) return;
+	if ( get_option( 'mic_conflicts_ignored' ) == 1 ) return; // Dismiss button has been clicked before.
+
+	// Allow the user to dismiss conflicts by URL parameter
+	if ( !empty($_REQUEST['mic_ignore_conflicts']) ) {
+		update_option('mic_conflicts_ignored', 1);
+		wp_redirect(remove_query_arg('mic_ignore_conflicts'));
+		exit;
+	}
+
+	// Collect conflicting plugins into an array.
+	$conflicting = array();
+
+	if ( $v = _mic_find_plugin('Regenerate Thumbnails') ) {
+		$v['reason'] = __('Will overwrite custom thumbnail cropping when regenerating thumbnails.', 'microp');
+		$conflicting[] = $v;
+	}
+
+	if ( $v = _mic_find_plugin('WP Smush') ) {
+		$v['reason'] = __('Will overwrite custom thumbnail cropping positions when images are "smushed".', 'microp');
+		$conflicting[] = $v;
+	}
+
+	if ( empty($conflicting) ) return; // No conflicts!
+
+	// Store conflicting plugins in a global, to carry over to the admin_notices hook.
+	global $mic_conflicting_plugins;
+	$mic_conflicting_plugins = $conflicting;
+
+	add_action( 'admin_notices', '_mic_display_conflicting_plugin_error' );
+}
+
+/**
+ * If the specified plugin name is found, returns information about the plugin.
+ *
+ * @param string $plugin_name
+ *
+ * @return array|bool
+ */
+function _mic_find_plugin( $plugin_name ) {
+	static $all_plugins = null;
+	if ( $all_plugins === null ) $all_plugins = get_plugins();
+
+	// Check if plugin name or title matches, return plugin info
+	foreach($all_plugins as $file => $plugin) {
+		if ( !is_plugin_active( $file ) ) continue;
+
+		if ( $plugin['Name'] == $plugin_name ) return array('file' => $file, 'plugin' => $plugin);
+		else if ( $plugin['Title'] == $plugin_name ) return array('file' => $file, 'plugin' => $plugin);
+	}
+
+	return false;
+}
+
+/**
+ * Displays a message to the admin about conflicting plugins.
+ */
+function _mic_display_conflicting_plugin_error() {
+	global $mic_conflicting_plugins;
+	if ( empty($mic_conflicting_plugins) ) return; // Should not occur anyway, but let's ensure we are giving a meaningful error to the user.
+
+	?>
+	<div class="error">
+		<p><strong><?php echo esc_html( __('Manual Image Crop - Warning:', 'microp') ); ?></strong> <?php echo esc_html( __('The plugins listed below may conflict with this plugin and should be disabled.') ); ?></p>
+
+		<ul class="ul-disc">
+			<?php
+			foreach( $mic_conflicting_plugins as $p ) {
+				$plugin = $p['plugin'];
+				$file = $p['file'];
+				$reason = $p['reason'];
+
+				$name = __( $plugin['Name'], $plugin['TextDomain'] );
+				$version = $plugin['Version'];
+				$url = $plugin['PluginURI'];
+				$nonce = wp_create_nonce( 'deactivate-plugin_' . $file );
+
+				$deactivate_url = false;
+				if ( current_user_can('activate_plugins') ) {
+					$deactivate_url = sprintf(
+						'plugins.php?action=deactivate&plugin=%s&plugin_status=inactive&paged=1&s&_wpnonce=%s',
+						urlencode($file),
+						urlencode($nonce)
+					);
+
+					$deactivate_url = admin_url( $deactivate_url );
+				}
+				?>
+				<li>
+					<strong><a href="<?php echo esc_attr($url); ?>" target="_blank" rel="external"><?php echo esc_html($name); ?> <?php echo esc_html($version); ?></a></strong>
+					<?php if ( $deactivate_url ) { ?>
+						(<a href="<?php echo esc_attr($deactivate_url); ?>"><?php _e('Deactivate'); ?></a>)
+					<?php } ?><br>
+					<?php echo esc_html( $reason ); ?>
+				</li>
+				<?php
+			}
+			?>
+		</ul>
+
+		<p><a href="<?php echo esc_attr(add_query_arg('mic_ignore_conflicts', 1)); ?>" class="button button-secondary">Dismiss</a></p>
+	</div>
+	<?php
+}

--- a/manual-image-crop.php
+++ b/manual-image-crop.php
@@ -3,7 +3,7 @@
 Plugin Name: Manual Image Crop
 Plugin URI: https://github.com/tomaszsita/wp-manual-image-crop
 Description: Plugin allows you to manually crop all the image sizes registered in your WordPress theme (in particular featured image). Simply click on the "Crop" link next to any image in your media library and select the area of the image you want to crop.
-Version: 1.12r1
+Version: 1.12r2
 Author: Tomasz Sita
 Author URI: https://github.com/tomaszsita
 License: GPL2
@@ -11,7 +11,7 @@ Text Domain: microp
 Domain Path: /languages/
 */
 
-define('mic_VERSION', '1.12r1');
+define('mic_VERSION', '1.12r2');
 
 include_once(dirname(__FILE__) . '/lib/ManualImageCropSettingsPage.php');
 

--- a/manual-image-crop.php
+++ b/manual-image-crop.php
@@ -3,7 +3,7 @@
 Plugin Name: Manual Image Crop
 Plugin URI: https://github.com/tomaszsita/wp-manual-image-crop
 Description: Plugin allows you to manually crop all the image sizes registered in your WordPress theme (in particular featured image). Simply click on the "Crop" link next to any image in your media library and select the area of the image you want to crop.
-Version: 1.12
+Version: 1.12r1
 Author: Tomasz Sita
 Author URI: https://github.com/tomaszsita
 License: GPL2
@@ -11,7 +11,7 @@ Text Domain: microp
 Domain Path: /languages/
 */
 
-define('mic_VERSION', '1.12');
+define('mic_VERSION', '1.12r1');
 
 include_once(dirname(__FILE__) . '/lib/ManualImageCropSettingsPage.php');
 

--- a/manual-image-crop.php
+++ b/manual-image-crop.php
@@ -3,7 +3,7 @@
 Plugin Name: Manual Image Crop
 Plugin URI: https://github.com/tomaszsita/wp-manual-image-crop
 Description: Plugin allows you to manually crop all the image sizes registered in your WordPress theme (in particular featured image). Simply click on the "Crop" link next to any image in your media library and select the area of the image you want to crop.
-Version: 1.12r2
+Version: 1.12r3
 Author: Tomasz Sita
 Author URI: https://github.com/tomaszsita
 License: GPL2
@@ -11,9 +11,11 @@ Text Domain: microp
 Domain Path: /languages/
 */
 
-define('mic_VERSION', '1.12r2');
+define('mic_VERSION', '1.12r3');
 
 include_once(dirname(__FILE__) . '/lib/ManualImageCropSettingsPage.php');
+
+include_once(dirname(__FILE__) . '/lib/plugin-conflicts.php'); // Show important plugin conflicts in an error message
 
 //mic - stands for Manual Image Crop
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Manual Image Crop ===
 Contributors: tomasz.sita
 Tags: crop, cropping, thumbnail, featured image, gallery, images, picture, image, image area
-Tested up to: 4.3
+Tested up to: 4.3.1
 Requires at least: 3.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Hi, this is my first pull request and I haven't published anything on WordPress.org yet. So you may want to thoroughly review any changes here. Mostly cosmetic changes, and one new but rather simple feature.

Here is the new settings page, to match the WP 4.3.1 style a bit better:

![image](https://cloud.githubusercontent.com/assets/2008464/11547945/c4ffab94-990c-11e5-9d4a-0d3590136329.png)

Here is the new popup page. Tabs have changed to match the media uploader better:

![image](https://cloud.githubusercontent.com/assets/2008464/11547959/d7934f9a-990c-11e5-860e-7ebf4e36f5cb.png)

Finally, the new feature offers a checkbox on the settings page. If enabled, we trigger the crop popup when you upload a new image through the media uploader. But it's off by default.
