### PR TITLE
Fix Broken crop window on Wordpress 4.7

### DIFF
--- a/assets/css/mic-admin.css
+++ b/assets/css/mic-admin.css
@@ -87,7 +87,8 @@
 .mic-editor-wrapper h4 {
 	float: left;
 	width: 100px;
-	margin-top: 23px;
+	margin-top: 10px;
+	margin-top: 0px;
 	line-height: 11px;
 }
 


### PR DESCRIPTION
This fixed the problem described in issue #62.